### PR TITLE
HomeFragment に UiEvent を導入し、本をクリックした時に詳細画面に遷移する環境を整えた

### DIFF
--- a/app/src/main/java/app/doggy/newmybrary/ui/book/register/RegisterFragment.kt
+++ b/app/src/main/java/app/doggy/newmybrary/ui/book/register/RegisterFragment.kt
@@ -55,15 +55,15 @@ class RegisterFragment : Fragment(R.layout.fragment_register) {
     lifecycleScope.launch {
       repeatOnLifecycle(Lifecycle.State.STARTED) {
         viewModel.uiState.collect { uiState ->
-          binding.registerButton.text = if (uiState.isLoading) "" else requireContext().getString(R.string.register_button_text)
-          binding.progressIndicator.isVisible = uiState.isLoading
-
-          if (uiState.isBookRegistered) findNavController().popBackStack()
-
+          if (uiState.isBookRegistered) {
+            findNavController().popBackStack()
+          }
           uiState.errorMessageRes?.let { errorMessageRes ->
             Snackbar.make(binding.coordinator, errorMessageRes, Snackbar.LENGTH_SHORT).show()
             viewModel.onErrorMessageShown()
           }
+          binding.registerButton.text = if (uiState.isLoading) "" else requireContext().getString(R.string.register_button_text)
+          binding.progressIndicator.isVisible = uiState.isLoading
         }
       }
     }

--- a/app/src/main/java/app/doggy/newmybrary/ui/home/BookItem.kt
+++ b/app/src/main/java/app/doggy/newmybrary/ui/home/BookItem.kt
@@ -15,7 +15,9 @@ data class BookItem(
     }
     binding.percentText.text = binding.root.context.getString(R.string.percent_text, uiModel.book.getPercent())
     binding.root.setOnClickListener {
-      // TODO: 詳細画面に遷移する処理
+      uiModel.book.id?.let {
+        uiModel.onClick(it)
+      }
     }
   }
 

--- a/app/src/main/java/app/doggy/newmybrary/ui/home/HomeFragment.kt
+++ b/app/src/main/java/app/doggy/newmybrary/ui/home/HomeFragment.kt
@@ -14,6 +14,7 @@ import androidx.recyclerview.widget.GridLayoutManager
 import app.doggy.newmybrary.R
 import app.doggy.newmybrary.databinding.FragmentHomeBinding
 import app.doggy.newmybrary.legacy.ReadActivity
+import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 
@@ -71,6 +72,13 @@ class HomeFragment : Fragment(R.layout.fragment_home) {
     lifecycleScope.launch {
       repeatOnLifecycle(Lifecycle.State.STARTED) {
         viewModel.uiState.collect { uiState ->
+          uiState.clickedBookId?.let {
+            // TODO: 詳細画面に遷移
+          }
+          uiState.errorMessageRes?.let { errorMessageRes ->
+            Snackbar.make(binding.coordinator, errorMessageRes, Snackbar.LENGTH_SHORT).show()
+            viewModel.onErrorMessageShown()
+          }
           // FIXME: 初回読み込み時以外は Indicator を表示しないようにする
           // FIXME: スケルトンスクリーンにする
           binding.progressIndicator.isVisible = uiState.isLoading

--- a/app/src/main/java/app/doggy/newmybrary/ui/home/HomeState.kt
+++ b/app/src/main/java/app/doggy/newmybrary/ui/home/HomeState.kt
@@ -1,13 +1,11 @@
 package app.doggy.newmybrary.ui.home
 
+import androidx.annotation.StringRes
+
 data class HomeState(
-  val uiModels: List<HomeUiModel>,
-  val isLoading: Boolean,
-) {
-  companion object {
-    fun initial() = HomeState(
-      uiModels = listOf(),
-      isLoading = false,
-    )
-  }
-}
+  val uiModels: List<HomeUiModel> = listOf(),
+  val isLoading: Boolean = false,
+  val clickedBookId: Long? = null,
+  @StringRes
+  val errorMessageRes: Int? = null,
+)

--- a/app/src/main/java/app/doggy/newmybrary/ui/home/HomeUiModel.kt
+++ b/app/src/main/java/app/doggy/newmybrary/ui/home/HomeUiModel.kt
@@ -5,5 +5,6 @@ import app.doggy.newmybrary.domain.model.Book
 sealed interface HomeUiModel {
   data class BookUiModel(
     val book: Book,
+    val onClick: (id: Long) -> Unit,
   ) : HomeUiModel
 }

--- a/app/src/main/java/app/doggy/newmybrary/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/app/doggy/newmybrary/ui/home/HomeViewModel.kt
@@ -2,6 +2,7 @@ package app.doggy.newmybrary.ui.home
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import app.doggy.newmybrary.R
 import app.doggy.newmybrary.domain.model.Book
 import app.doggy.newmybrary.domain.repository.BookRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -16,7 +17,7 @@ import kotlinx.coroutines.launch
 class HomeViewModel @Inject constructor(
   private val bookRepository: BookRepository,
 ) : ViewModel() {
-  private val _uiState = MutableStateFlow(HomeState.initial())
+  private val _uiState = MutableStateFlow(HomeState())
   val uiState: StateFlow<HomeState> = _uiState.asStateFlow()
 
   fun onViewCreated() {
@@ -32,10 +33,18 @@ class HomeViewModel @Inject constructor(
           )
         }
       }.onFailure {
-        // TODO: エラーハンドリング
-        _uiState.update { it.copy(isLoading = false) }
+        _uiState.update {
+          it.copy(
+            isLoading = false,
+            errorMessageRes = R.string.error_failed_to_get_books,
+          )
+        }
       }
     }
+  }
+
+  fun onErrorMessageShown() {
+    _uiState.update { it.copy(errorMessageRes = null) }
   }
 
   private fun onBookClick(id: Long) {

--- a/app/src/main/java/app/doggy/newmybrary/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/app/doggy/newmybrary/ui/home/HomeViewModel.kt
@@ -47,11 +47,12 @@ class HomeViewModel @Inject constructor(
     _uiState.update { it.copy(errorMessageRes = null) }
   }
 
-  private fun onBookClick(id: Long) {
+  private fun onBookClicked(id: Long) {
+    _uiState.update { it.copy(clickedBookId = id) }
   }
 
   private fun Book.toHomeUiModel() = HomeUiModel.BookUiModel(
     book = this,
-    onClick = ::onBookClick,
+    onClick = ::onBookClicked,
   )
 }

--- a/app/src/main/java/app/doggy/newmybrary/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/app/doggy/newmybrary/ui/home/HomeViewModel.kt
@@ -38,7 +38,11 @@ class HomeViewModel @Inject constructor(
     }
   }
 
+  private fun onBookClick(id: Long) {
+  }
+
   private fun Book.toHomeUiModel() = HomeUiModel.BookUiModel(
     book = this,
+    onClick = ::onBookClick,
   )
 }

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -21,6 +21,15 @@
     app:layout_constraintTop_toTopOf="parent"
     />
 
+  <androidx.coordinatorlayout.widget.CoordinatorLayout
+    android:id="@+id/coordinator"
+    android:layout_width="0dp"
+    android:layout_height="wrap_content"
+    app:layout_constraintBottom_toTopOf="@id/barcode_button"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    />
+
   <com.google.android.material.floatingactionbutton.FloatingActionButton
     android:id="@+id/barcode_button"
     android:layout_width="wrap_content"

--- a/app/src/main/res/values/strings_home.xml
+++ b/app/src/main/res/values/strings_home.xml
@@ -4,4 +4,5 @@
   <string name="register_button_content_description">Transition to the book registration screen.</string>
   <string name="empty_text">Register your book!</string>
   <string name="percent_text">%d%%</string>
+  <string name="error_failed_to_get_books">Failed to retrieve registered books.</string>
 </resources>


### PR DESCRIPTION
## :thought_balloon: 背景
- HomeFragment に UiEvent を導入するのを後回しにしていた
- 本をクリックしたときに詳細画面に遷移する処理の実装を後回しにしていた

## :sparkles: 実装内容
- UiEvent として、clickedBookId, errorMessageRes を追加
- 本をクリックした時の処理の実装（実際の画面遷移はまだ）

## :white_check_mark: 動作確認
- [x] Snackbar が想定通りの位置・様子で表示されるか
- [x] 本をクリックした時、 UiEvent としてクリックした本の id が Fragment まで伝わってくるか

## :art: UI差分
| Before | After |
|:--:|:--:|
| <img src="" width="300px" /> | <img src="https://user-images.githubusercontent.com/49048577/200667192-38017859-baac-49e0-a29c-69638da6b397.png" width="300px" /> |

## :link: 関連リンク
